### PR TITLE
Utilize travis build stages

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ jobs:
         - yarn install
         - npm install -g codecov codeclimate-test-reporter
       script:
+        - yarn test
         - nyc report --report-dir=coverage/ --reporter=text-lcov > coverage.lcov
         - codecov
         - codeclimate-test-reporter < coverage.lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,11 +11,11 @@ script:
 jobs:
   include:
     - stage: coverage
-    node_js: "lts/*"
-    install:
-      - yarn install
-      - npm install -g codecov codeclimate-test-reporter
-    script:
-      - nyc report --report-dir=coverage/ --reporter=text-lcov > coverage.lcov
-      - codecov
-      - codeclimate-test-reporter < coverage.lcov
+      node_js: "lts/*"
+      install:
+        - yarn install
+        - npm install -g codecov codeclimate-test-reporter
+      script:
+        - nyc report --report-dir=coverage/ --reporter=text-lcov > coverage.lcov
+        - codecov
+        - codeclimate-test-reporter < coverage.lcov

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,19 @@ node_js:
   - "lts/*"
   - "node"
   - "8"
-install:
-  - yarn install
-  - npm install -g codecov codeclimate-test-reporter
 
 script:
-  - npm run test
-  - nyc report --report-dir=coverage/ --reporter=text-lcov > coverage.lcov
-  - codecov
-  - codeclimate-test-reporter < coverage.lcov
+  - echo "Running tests against $(node -v) ..."
+  - yarn test
+
+jobs:
+  include:
+    - stage: coverage
+    node_js: "lts/*"
+    install:
+      - yarn install
+      - npm install -g codecov codeclimate-test-reporter
+    script:
+      - nyc report --report-dir=coverage/ --reporter=text-lcov > coverage.lcov
+      - codecov
+      - codeclimate-test-reporter < coverage.lcov

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,2 @@
+comment:
+  behavior: new


### PR DESCRIPTION
This should prevent code coverage from commenting multiple times like on #2. Runs tests on 3 node versions and then generates coverage on the lts version if the tests were successful.