### PR TITLE
chore: add config:init command

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,8 +61,9 @@ USAGE
 <!-- commands -->
 # 🔨 Command Topics
 
+* [`gsv config`](docs/config.md) - manage gsv config
 * [`gsv help`](docs/help.md) - display help for gsv
-* [`gsv new`](docs/new.md) - creates a new gatsby blog
+* [`gsv new`](docs/new.md) - create new instances (blog|post|page)
 
 <!-- commandsstop -->
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -3,19 +3,21 @@
 
 manage gsv config
 
-* [`gsv config:init [FILE]`](#gsv-configinit-file)
+* [`gsv config:init`](#gsv-configinit)
 
-## `gsv config:init [FILE]`
+## `gsv config:init`
 
 initialize a fresh .gsvrc file
 
 ```
 USAGE
-  $ gsv config:init [FILE]
+  $ gsv config:init
 
 OPTIONS
-  -f, --force
-  -h, --help   show CLI help
+  -f, --force        overrides existing .gsvrc
+  -h, --help         show CLI help
+  -t, --title=title  (required) blog title
+  -u, --url=url      (required) blog url
 ```
 
 _See code: [src/commands/config/init.ts](https://github.com/syntra/gsv/blob/v0.0.1/src/commands/config/init.ts)_

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,21 @@
+`gsv config`
+============
+
+manage gsv config
+
+* [`gsv config:init [FILE]`](#gsv-configinit-file)
+
+## `gsv config:init [FILE]`
+
+initialize a fresh .gsvrc file
+
+```
+USAGE
+  $ gsv config:init [FILE]
+
+OPTIONS
+  -f, --force
+  -h, --help   show CLI help
+```
+
+_See code: [src/commands/config/init.ts](https://github.com/syntra/gsv/blob/v0.0.1/src/commands/config/init.ts)_

--- a/docs/new.md
+++ b/docs/new.md
@@ -1,7 +1,7 @@
 `gsv new`
 =========
 
-creates a new gatsby blog
+create new instances (blog|post|page)
 
 * [`gsv new:blog [PATH]`](#gsv-newblog-path)
 * [`gsv new:page [FILE]`](#gsv-newpage-file)

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "chalk": "^2.4.1",
     "emojic": "^1.1.14",
     "gatsby-cli": "^2.4.1",
+    "iniparser": "^1.0.5",
     "rimraf": "^2.6.2",
     "tslib": "^1",
     "yeoman-environment": "^2.3.3",

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "iniparser": "^1.0.5",
     "rimraf": "^2.6.2",
     "tslib": "^1",
+    "yaml": "^1.0.0-rc.8",
     "yeoman-environment": "^2.3.3",
     "yeoman-generator": "^3.1.1"
   },

--- a/package.json
+++ b/package.json
@@ -62,7 +62,15 @@
     "bin": "gsv",
     "plugins": [
       "@oclif/plugin-help"
-    ]
+    ],
+    "topics": {
+      "config": {
+        "description": "manage gsv config"
+      },
+      "new": {
+        "description": "create new instances (blog|post|page)"
+      }
+    }
   },
   "repository": "syntra/gsv",
   "scripts": {

--- a/src/commands/config/init.ts
+++ b/src/commands/config/init.ts
@@ -5,7 +5,7 @@ import Command from "../../command";
 import git from "../../utils/git";
 
 export default class ConfigInit extends Command {
-  static description = "describe the command here";
+  static description = "initialize a fresh .gsvrc file";
 
   static flags = {
     help: flags.help({ char: "h" }),
@@ -35,6 +35,7 @@ export default class ConfigInit extends Command {
     // TODO: save config to .gsvrc
     this.log(config);
 
+    // TODO: allow the force flag to override existing .gsvrc file
     if (flags.force) {
       this.log(`you input --force and --file: ${args.file}`);
     }

--- a/src/commands/config/init.ts
+++ b/src/commands/config/init.ts
@@ -1,0 +1,42 @@
+import { flags } from "@oclif/command";
+import YAML from "yaml";
+
+import Command from "../../command";
+import git from "../../utils/git";
+
+export default class ConfigInit extends Command {
+  static description = "describe the command here";
+
+  static flags = {
+    help: flags.help({ char: "h" }),
+    // flag with no value (-f, --force)
+    force: flags.boolean({ char: "f" }),
+  };
+
+  static args = [{ name: "file" }];
+
+  mkConfig(config: { name: string; email: string }) {
+    const author = { name: config.name, email: config.email };
+    return YAML.stringify({ author });
+  }
+
+  async run() {
+    const { args, flags } = this.parse(ConfigInit);
+
+    const gitConfig = await git.config();
+
+    if (!gitConfig) {
+      // TODO: start yeoman generator when no config is found
+      this.error("No config found");
+    }
+
+    const config = this.mkConfig({ ...gitConfig.user });
+
+    // TODO: save config to .gsvrc
+    this.log(config);
+
+    if (flags.force) {
+      this.log(`you input --force and --file: ${args.file}`);
+    }
+  }
+}

--- a/src/commands/config/init.ts
+++ b/src/commands/config/init.ts
@@ -15,7 +15,10 @@ export default class ConfigInit extends Command {
       required: true,
     }),
     url: flags.string({ char: "u", description: "blog url", required: true }),
-    force: flags.boolean({ char: "f" }),
+    force: flags.boolean({
+      char: "f",
+      description: "overrides existing .gsvrc",
+    }),
   };
 
   async run() {

--- a/src/global.d.ts
+++ b/src/global.d.ts
@@ -1,2 +1,3 @@
 declare module "yeoman-environment";
 declare module "emojic";
+declare module "yaml";

--- a/src/types.ts
+++ b/src/types.ts
@@ -3,3 +3,19 @@ export interface CLIError {
   help?: string;
   exit: number;
 }
+
+export interface Author {
+  name: string;
+  email: string;
+  social?: Array<Social>;
+}
+
+export interface Social {
+  [key: string]: string;
+}
+
+export interface GSVRC {
+  title: string;
+  url: string;
+  author: Author;
+}

--- a/src/utils/git/clone.ts
+++ b/src/utils/git/clone.ts
@@ -75,4 +75,4 @@ const clone = async (
   });
 };
 
-export default { clone };
+export default clone;

--- a/src/utils/git/config.ts
+++ b/src/utils/git/config.ts
@@ -1,0 +1,16 @@
+const parser = require("iniparser");
+const path = require("path");
+
+interface Config {
+  user: { email: string; name: string };
+}
+
+const config = async (): Promise<Config | any> => {
+  const gitConfigPath = path.join(
+    process.env.HOME || process.env.USERPROFILE,
+    ".gitconfig"
+  );
+  return new Promise(resolve => resolve(parser.parseSync(gitConfigPath)));
+};
+
+export default config;

--- a/src/utils/git/index.ts
+++ b/src/utils/git/index.ts
@@ -1,0 +1,4 @@
+import clone from "./clone";
+import config from "./config";
+
+export default { clone, config };

--- a/src/utils/gsvrc/exists.ts
+++ b/src/utils/gsvrc/exists.ts
@@ -1,0 +1,11 @@
+import { stat } from "fs";
+
+const exists = async (): Promise<Error | any> =>
+  new Promise(resolve =>
+    stat(".gsvrc", (err: Error) => {
+      if (err) resolve(false);
+      resolve(true);
+    })
+  );
+
+export default exists;

--- a/src/utils/gsvrc/index.ts
+++ b/src/utils/gsvrc/index.ts
@@ -1,0 +1,4 @@
+import exists from "./exists";
+import write from "./write";
+
+export default { exists, write };

--- a/src/utils/gsvrc/write.ts
+++ b/src/utils/gsvrc/write.ts
@@ -12,7 +12,6 @@ const write = async (config: GSVRC, force?: boolean): Promise<Error | any> => {
     );
   }
   return new Promise(resolve => {
-    console.log("writing file");
     writeFile(".gsvrc", YAML.stringify(config), resolve);
   });
 };

--- a/src/utils/gsvrc/write.ts
+++ b/src/utils/gsvrc/write.ts
@@ -1,0 +1,20 @@
+import { writeFile } from "fs";
+import YAML from "yaml";
+
+import { GSVRC } from "../../types";
+
+import exists from "./exists";
+
+const write = async (config: GSVRC, force?: boolean): Promise<Error | any> => {
+  if ((await exists()) && !force) {
+    return new Promise((_, reject) =>
+      reject(".gsvrc already exists. Use -f to override,")
+    );
+  }
+  return new Promise(resolve => {
+    console.log("writing file");
+    writeFile(".gsvrc", YAML.stringify(config), resolve);
+  });
+};
+
+export default write;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,8 @@
     "strict": true,
     "target": "es2017",
     "composite": true,
-    "sourceMap": true
+    "sourceMap": true,
+    "noImplicitAny": false
   },
   "include": ["src/**/*"]
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3613,6 +3613,10 @@ yallist@^2.1.2:
   version "2.1.2"
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-2.1.2.tgz#1c11f9218f076089a47dd512f93c6699a6a81d52"
 
+yaml@^1.0.0-rc.8:
+  version "1.0.0-rc.8"
+  resolved "https://registry.yarnpkg.com/yaml/-/yaml-1.0.0-rc.8.tgz#e5604c52b7b07b16e469bcf875ab0dfe08c50d42"
+
 yargs-parser@^10.1.0:
   version "10.1.0"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-10.1.0.tgz#7202265b89f7e9e9f2e5765e0fe735a905edbaa8"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1653,6 +1653,10 @@ ini@^1.3.4, ini@~1.3.0:
   version "1.3.5"
   resolved "https://registry.yarnpkg.com/ini/-/ini-1.3.5.tgz#eee25f56db1c9ec6085e0c22778083f596abf927"
 
+iniparser@^1.0.5:
+  version "1.0.5"
+  resolved "https://registry.yarnpkg.com/iniparser/-/iniparser-1.0.5.tgz#836d6befe6dfbfcee0bccf1cf9f2acc7027f783d"
+
 inquirer@^3.0.1:
   version "3.3.0"
   resolved "https://registry.yarnpkg.com/inquirer/-/inquirer-3.3.0.tgz#9dd2f2ad765dcab1ff0443b491442a20ba227dc9"


### PR DESCRIPTION
## Description

Adds `gsv config:init`, which generates a `.gsvrc` file containing properties for gsv blog.

## Spec

- `.gsvrc` uses `yaml` syntax
- `author` fields are parsed from global git config
  - if git config can't be loaded, launch yeoman generator for filling in the author
- after parsing `author`, a new yeoman generator should open to fill in the rest of the site's data:
  - `siteTitle`: title of the blog
  - `siteUrl`: base path for the blog (should be check boxes, none of them are required)
  - `social`: object with social links
    - `twitter`
    - `github`
    - `facebook`
    - `youtube`
    - `instagram`
    - `soundcloud`